### PR TITLE
fix-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "worksheet",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://hongyan.cqupt.edu.cn/",
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,17 @@ import Worksheet from './page/home'
 
 import * as serviceWorker from './serviceWorker';
 
+// Create-react-app 创建的直接在 package.json 里添加 proxy 就能代理
+// 但是只能开发环境使用，线上环境还是要访问接口，跨域的话可以自己写个 node 代理
+// 放自己服务器上
+fetch('/api/kebiao', {
+  method: 'POST',
+  body: 'stu_num=2018214294',
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+  },
+}).then(r => r.json()).then(console.log)
+
 ReactDOM.render(<Worksheet />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
Create-react-app 创建的直接在 package.json 里添加 proxy 就能代理，但是只能开发环境使用，线上环境还是要访问接口，跨域的话可以自己写个 node 代理，放自己服务器上

create-react-app 里 eject 后可以修改脚手架内部具体 webpack 的配置，你不 eject 直接写 webpack 配置没用，一般项目用不到 eject